### PR TITLE
Minor fixes through week4 

### DIFF
--- a/Inference_for_Paired_Data/lesson.yaml
+++ b/Inference_for_Paired_Data/lesson.yaml
@@ -71,7 +71,7 @@
 
 #11
 - Class: mult_question
-  Output: At a 10% level of significance, the would the null hypothesis of normality be rejected for the population of differences?  Recall that the null hypothesis is that the sample comes from a normally distributed population (vs the alternative that is does not).
+  Output: At a 10% level of significance, would the null hypothesis of normality be rejected for the population of differences?  Recall that the null hypothesis is that the sample comes from a normally distributed population (vs the alternative that is does not).
   AnswerChoices: yes; no
   CorrectAnswer: no
   AnswerTests: omnitest(correctVal='no')
@@ -117,7 +117,7 @@
 
 #18
 - Class: cmd_question
-  Output: The wilcox.test function can also produce a condifence interval for the median by entering wilcox.test(Precryotherapy,After17Min,paired=TRUE,conf.int) at the command prompt.
+  Output: The wilcox.test function can also produce a condifence interval for the median by entering wilcox.test(Precryotherapy,After17Min,paired=TRUE,conf.int=TRUE) at the command prompt.
   CorrectAnswer: wilcox.test(Precryotherapy,After17Min,paired=TRUE,conf.int=TRUE)
   AnswerTests:  omnitest(correctExpr='wilcox.test(Precryotherapy,After17Min,paired=TRUE,conf.int=TRUE)')
   Hint: Type or paste wilcox.test(Precryotherapy,After17Min,paired=TRUE,conf.int=TRUE) at the command prompt.

--- a/Inference_for_Paired_Data/lesson.yaml
+++ b/Inference_for_Paired_Data/lesson.yaml
@@ -4,7 +4,7 @@
   Author: Dave Reineke
   Type: Standard
   Organization: University of Wisconsin - La Crosse
-  Version: 2.2.0
+  Version: 2.2.01
 
 #1
 - Class: text

--- a/Two-Sample_Inference_for_Means/lesson.yaml
+++ b/Two-Sample_Inference_for_Means/lesson.yaml
@@ -67,7 +67,7 @@
 
 #12
 - Class: mult_question
-  Output: At a 5% level of significance, the would the null hypothesis of equal population means be rejected?  
+  Output: At a 5% level of significance, would the null hypothesis of equal population means be rejected?  
   AnswerChoices: yes; no
   CorrectAnswer: yes
   AnswerTests: omnitest(correctVal='yes')

--- a/Two-Sample_Inference_for_Means/lesson.yaml
+++ b/Two-Sample_Inference_for_Means/lesson.yaml
@@ -136,7 +136,7 @@
 
 #23
 - Class: mult_question
-  Output: At a 5% level of significance, the would the null hypothesis of normality be rejected for the diastolic BP of males?  Recall that the null hypothesis is that the sample comes from a normally distributed population (vs the alternative that is does not).
+  Output: At a 5% level of significance, would the null hypothesis of normality be rejected for the diastolic BP of males?  Recall that the null hypothesis is that the sample comes from a normally distributed population (vs the alternative that is does not).
   AnswerChoices: yes; no
   CorrectAnswer: no
   AnswerTests: omnitest(correctVal='no')
@@ -151,7 +151,7 @@
 
 #25
 - Class: mult_question
-  Output: At a 5% level of significance, the would the null hypothesis of normality be rejected for the diastolic BP of females?
+  Output: At a 5% level of significance, would the null hypothesis of normality be rejected for the diastolic BP of females?
   AnswerChoices: yes; no
   CorrectAnswer: no
   AnswerTests: omnitest(correctVal='no')
@@ -170,7 +170,7 @@
 
 #28
 - Class: mult_question
-  Output: At a 5% level of significance, the would the null hypothesis of equal population variances be rejected for the diastolic BP of adult males and females in the US?
+  Output: At a 5% level of significance, would the null hypothesis of equal population variances be rejected for the diastolic BP of adult males and females in the US?
   AnswerChoices: yes; no
   CorrectAnswer: no
   AnswerTests: omnitest(correctVal='no')

--- a/Two-Sample_Inference_for_Means/lesson.yaml
+++ b/Two-Sample_Inference_for_Means/lesson.yaml
@@ -4,7 +4,7 @@
   Author: Dave Reineke
   Type: Standard
   Organization: University of Wisconsin - La Crosse
-  Version: 2.2.0
+  Version: 2.2.0.1
 
 #1
 - Class: text

--- a/Two-Sample_Inference_for_Means/lesson.yaml
+++ b/Two-Sample_Inference_for_Means/lesson.yaml
@@ -34,7 +34,7 @@
 
 #6
 - Class: cmd_question
-  Output: This time construct a 90% separate-variance t-interval to estimate the difference in population means. Use the option "conf.level=0.90"" to adjust the level of confidence in the t.test function. Remember that you can bring up previous commands for editing at the command prompt using the up arrow.  Do this now.
+  Output: This time construct a 90% separate-variance t-interval to estimate the difference in population means. Use the option "conf.level=0.90" to adjust the level of confidence in the t.test function. Remember that you can bring up previous commands for editing at the command prompt using the up arrow.  Do this now.
   CorrectAnswer: t.test(DiasBP~Sex,data=HealthExam, conf.level=0.90)$conf
   AnswerTests:  omnitest(correctExpr='t.test(DiasBP~Sex,data=HealthExam, conf.level=0.90)$conf')
   Hint: Type t.test(DiasBP~Sex,data=HealthExam, conf.level=0.90)$conf at the command prompt.
@@ -93,7 +93,7 @@
 
 #16
 - Class: text
-  Output: Comparing this output with that for the two-tailed separate-variance t-test, note the slight differences the values for the test statistic, df, and p-value.  You may also notice that for this sample data the differences between the two procedures are not very large.  It is not uncommon fo for the pooled and unpooled t-tests to yield the same results.
+  Output: Comparing this output with that for the two-tailed separate-variance t-test, note the slight differences the values for the test statistic, df, and p-value.  You may also notice that for this sample data the differences between the two procedures are not very large.  It is not uncommon for the pooled and unpooled t-tests to yield the same results.
 
 #17
 - Class: text

--- a/Wilcoxon_Rank_Sum/lesson.yaml
+++ b/Wilcoxon_Rank_Sum/lesson.yaml
@@ -66,7 +66,7 @@
 
 #11
 - Class: mult_question
-  Output: At a 5% level of significance, the would the null hypothesis of normality be rejected for the systolic BP of males?  Recall that the null hypothesis is that the sample comes from a normally distributed population (vs the alternative that is does not).
+  Output: At a 5% level of significance, would the null hypothesis of normality be rejected for the systolic BP of males?  Recall that the null hypothesis is that the sample comes from a normally distributed population (vs the alternative that is does not).
   AnswerChoices: yes; no
   CorrectAnswer: yes
   AnswerTests: omnitest(correctVal='yes')
@@ -81,7 +81,7 @@
 
 #13
 - Class: mult_question
-  Output: At a 5% level of significance, the would the null hypothesis of normality be rejected for the systolic BP of females?
+  Output: At a 5% level of significance, would the null hypothesis of normality be rejected for the systolic BP of females?
   AnswerChoices: yes; no
   CorrectAnswer: yes
   AnswerTests: omnitest(correctVal='yes')
@@ -207,7 +207,7 @@
 
 #32
 - Class: mult_question
-  Output: At a 5% level of significance, the would the null hypothesis of normality be rejected for the choloesterol of the 18 to 35 age group?  Note how much smaller the p-value is for this sample than for the systolic BP samples.
+  Output: At a 5% level of significance, would the null hypothesis of normality be rejected for the choloesterol of the 18 to 35 age group?  Note how much smaller the p-value is for this sample than for the systolic BP samples.
   AnswerChoices: yes; no
   CorrectAnswer: yes
   AnswerTests: omnitest(correctVal='yes')
@@ -222,7 +222,7 @@
 
 #34
 - Class: mult_question
-  Output: At a 5% level of significance, the would the null hypothesis of normality be rejected for the choloesterol for the 36 to 65 age group?
+  Output: At a 5% level of significance, would the null hypothesis of normality be rejected for the choloesterol for the 36 to 65 age group?
   AnswerChoices: yes; no
   CorrectAnswer: yes
   AnswerTests: omnitest(correctVal='yes')


### PR DESCRIPTION
Submits changes for two lessons: 

- Inference_for_Paired_Data / Q18 had incorrect prompt, needs `conf.int=TRUE` rather than just `conf.int`. 

- Removed various extra words in the paired data lesson and two-sampled inference lessons and an extra quotation mark. 

